### PR TITLE
feat: add Donchian and Williams %R indicators

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,11 @@ This project fetches daily stock data for multiple tickers using `yahoo-finance2
 - Relative Strength Index (RSI)
 - Stochastic oscillator %K
 - Bollinger Bands (20-day, 2 standard deviations)
+- Donchian Channels (20-day)
+- Williams %R (14-day)
 - Fear & Greed Index (alternative.me)
-- Derived BUY/HOLD opinion
+- Derived BUY/HOLD opinion weighted by indicator reliability and basic pattern detection
+- Basic detection of bullish chart patterns (ascending triangle, bullish flag, double bottom, falling wedge, island reversal)
 
 ## Usage
 1. **Configure tickers** – edit `src/index.ts` and adjust the `TICKERS` array. Default tickers:


### PR DESCRIPTION
## Summary
- compute Donchian Channels and Williams %R for each ticker
- store new indicators in CSV outputs
- incorporate Donchian and Williams %R into BUY/HOLD opinion
- weight indicators by reliability and add basic bullish pattern detection with a confidence score
- weigh stochastic oscillator in opinion calculation and document BUY_THRESHOLD rationale

## Testing
- `pnpm start` *(fails: fetch failed: caused by AggregateError [ENETUNREACH])*

------
https://chatgpt.com/codex/tasks/task_e_6899e10f3b808328b276fe1817bbc02e