### PR TITLE
feat: add ticker arg for start script

### DIFF
--- a/.github/workflows/daily-data.yml
+++ b/.github/workflows/daily-data.yml
@@ -16,7 +16,7 @@ jobs:
           cache: 'pnpm'
       - run: corepack enable
       - run: pnpm install --frozen-lockfile
-      - run: pnpm start
+      - run: pnpm start --ticker=TSLA,PLTR,IONQ,GEV,RXRX,DNA
       - uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: 'chore: daily stock data update'

--- a/README.md
+++ b/README.md
@@ -14,13 +14,15 @@ This project fetches daily stock data for multiple tickers using `yahoo-finance2
 - Basic detection of bullish chart patterns (ascending triangle, bullish flag, double bottom, falling wedge, island reversal)
 
 ## Usage
-1. **Configure tickers** – edit `src/index.ts` and adjust the `TICKERS` array. Default tickers:
-   `TSLA`, `PLTR`, `IONQ`, `GEV`, `RXRX`, `DNA`.
-2. **Install & run**
+1. **Install & run**
    ```bash
    pnpm install
-   pnpm start
+   pnpm start --ticker=TSLA,PLTR,IONQ,GEV,RXRX,DNA
    ```
+
+   Pass any comma-separated list of tickers via `--ticker`. If omitted, the
+   script exits with an error message. Argument parsing is handled by
+   [commander](https://github.com/tj/commander.js).
 
 Each run appends data to a file named `public/stock_data_YYYYMMDD.csv`.
 

--- a/package.json
+++ b/package.json
@@ -2,10 +2,11 @@
   "name": "stock-checker",
   "version": "1.0.0",
   "scripts": {
-    "start": "tsx src/index.ts",
-    "start:pretty": "tsx src/index.ts | pino-pretty"
+    "start": "tsx src/index.ts --ticker=TSLA,PLTR,IONQ,GEV,RXRX,DNA",
+    "start:pretty": "tsx src/index.ts --ticker=TSLA,PLTR,IONQ,GEV,RXRX,DNA | pino-pretty"
   },
   "dependencies": {
+    "commander": "^12.0.0",
     "luxon": "^3.6.1",
     "pino": "^9.7.0",
     "pino-pretty": "^13.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      commander:
+        specifier: ^12.0.0
+        version: 12.0.0
       luxon:
         specifier: ^3.6.1
         version: 3.6.1


### PR DESCRIPTION
## Summary
- parse tickers with Commander for robust CLI option handling
- include Commander dependency and document usage

## Testing
- `pnpm add commander@12 --lockfile-only` *(fails: GET https://registry.npmjs.org/commander: Forbidden)*
- `pnpm exec tsx src/index.ts` *(fails: Cannot find module 'commander')*
- `pnpm start` *(fails: Cannot find module 'commander')*

------
https://chatgpt.com/codex/tasks/task_e_6899ed5531a48328871341def6668f9e