### PR TITLE
feat: add sell signal logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This project fetches daily stock data for multiple tickers using `yahoo-finance2
 - Donchian Channels (20-day)
 - Williams %R (14-day)
 - Fear & Greed Index (alternative.me)
-- Derived BUY/HOLD opinion weighted by indicator reliability and basic pattern detection
+- Derived BUY/HOLD/SELL opinion weighted by indicator reliability and basic pattern detection
 - Basic detection of bullish chart patterns (ascending triangle, bullish flag, double bottom, falling wedge, island reversal)
 
 ## Usage


### PR DESCRIPTION
## Summary
- introduce SELL threshold and scoring to flag overbought conditions
- document BUY/HOLD/SELL opinions in README

## Testing
- `pnpm exec tsc --noEmit && echo "tsc success"`
- `npm_config_ticker=AAPL pnpm start` *(fails: fetch failed: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6899f1e0b4f48328900610e2d1afc34b