### PR TITLE
fix(ci): ensure pnpm v10 is installed

### DIFF
--- a/.github/workflows/daily-data.yml
+++ b/.github/workflows/daily-data.yml
@@ -10,11 +10,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+          run_install: false
       - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: 'pnpm'
-      - run: corepack enable
+          cache-dependency-path: pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
       - run: pnpm start --ticker=TSLA,PLTR,IONQ,GEV,RXRX,DNA,BMNR
       - uses: stefanzweifel/git-auto-commit-action@v5


### PR DESCRIPTION
## Summary
- install pnpm v10 using latest pnpm/action-setup
- keep workflow using latest actions/checkout

## Testing
- `pnpm install --frozen-lockfile`


------
https://chatgpt.com/codex/tasks/task_e_689bead2b66083289fe418f0e3c656e3