### PR TITLE
chore: adjust daily workflow schedule

### DIFF
--- a/.github/workflows/daily-data.yml
+++ b/.github/workflows/daily-data.yml
@@ -2,7 +2,7 @@ name: Daily stock data
 
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 23 * * *' # Run ~2 hours after U.S. market close
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- run daily update two hours after US market close

## Testing
- `pnpm run test` *(fails: Missing script: test)*

------
https://chatgpt.com/codex/tasks/task_e_689c0730516883288dad39630129f651