### PR TITLE
ci: allow auto-commit action to push

### DIFF
--- a/.github/workflows/daily-data.yml
+++ b/.github/workflows/daily-data.yml
@@ -5,11 +5,10 @@ on:
     - cron: '0 23 * * *' # Run ~2 hours after U.S. market close
   workflow_dispatch:
 
-permissions:
-  contents: write
-
 jobs:
   update:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/daily-data.yml
+++ b/.github/workflows/daily-data.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 23 * * *' # Run ~2 hours after U.S. market close
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   update:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add `contents: write` permission to allow git-auto-commit-action to push changes

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689d3eb3ed4c83289d370912ea20f46d