### PR TITLE
ci: scope auto-commit permission to update job

### DIFF
--- a/.github/workflows/daily-data.yml
+++ b/.github/workflows/daily-data.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   update:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- move contents write permission to update job so git-auto-commit-action can push updates

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689d3eb3ed4c83289d370912ea20f46d