### PR TITLE
feat: add slack notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,26 @@ This project fetches daily stock data for multiple tickers using `yahoo-finance2
 ## Usage
 1. **Install & run**
    ```bash
-   pnpm install
-   pnpm start --ticker=TSLA,PLTR,IONQ,GEV,RXRX,DNA
+  pnpm install
+  pnpm start --ticker=TSLA,PLTR,IONQ,GEV,RXRX,DNA
+  ```
+
+  Pass any comma-separated list of tickers via `--ticker`. If omitted, the
+  script exits with an error message. Argument parsing is handled by
+  [commander](https://github.com/tj/commander.js).
+
+   To send Slack notifications for tickers that return a **BUY** or **SELL**
+   opinion, provide a webhook URL either via the `--slack-webhook` option or the
+   `SLACK_WEBHOOK_URL` environment variable:
+
+   ```bash
+   SLACK_WEBHOOK_URL=https://hooks.slack.com/services/XXX pnpm start --ticker=TSLA,PLTR
+   # or
+   pnpm start --ticker=TSLA,PLTR --slack-webhook=https://hooks.slack.com/services/XXX
    ```
 
-   Pass any comma-separated list of tickers via `--ticker`. If omitted, the
-   script exits with an error message. Argument parsing is handled by
-   [commander](https://github.com/tj/commander.js).
+   Each Slack message starts with the date, ticker, and opinion followed by
+   bullet-pointed indicator values.
 
 Each run appends data to a file named `public/stock_data_YYYYMMDD.csv`.
 


### PR DESCRIPTION
## Summary
- allow passing Slack webhook to send BUY/SELL alerts
- include indicator bullet points in Slack messages
- document Slack notification usage
- post Slack alerts after CSV writing

## Testing
- `pnpm exec tsc --noEmit && echo tsc-ok`
- `SLACK_WEBHOOK_URL=https://httpbin.org/post pnpm exec tsx src/index.ts --ticker=TSLA` *(fails: fetch failed: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_689fbf1f72bc83288bce7092370b40d4