### PR TITLE
feat: add INTC and UPST tickers

### DIFF
--- a/.github/workflows/daily-data.yml
+++ b/.github/workflows/daily-data.yml
@@ -22,7 +22,7 @@ jobs:
           cache: 'pnpm'
           cache-dependency-path: pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
-      - run: pnpm start --ticker=TSLA,PLTR,IONQ,GEV,RXRX,DNA,BMNR
+      - run: pnpm start --ticker=TSLA,PLTR,IONQ,GEV,RXRX,DNA,BMNR,INTC,UPST
       - uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: 'chore: daily stock data update'

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This project fetches daily stock data for multiple tickers using `yahoo-finance2
 1. **Install & run**
    ```bash
   pnpm install
-  pnpm start --ticker=TSLA,PLTR,IONQ,GEV,RXRX,DNA
+  pnpm start --ticker=TSLA,PLTR,IONQ,GEV,RXRX,DNA,BMNR,INTC,UPST
   ```
 
   Pass any comma-separated list of tickers via `--ticker`. If omitted, the
@@ -37,6 +37,6 @@ This project fetches daily stock data for multiple tickers using `yahoo-finance2
    Each Slack message starts with the date, ticker, and opinion followed by
    bullet-pointed indicator values.
 
-Each run appends data to a file named `public/stock_data_YYYYMMDD.csv`.
+Each run appends data to a file named `public/stock_data_YYYYMMDD.csv`, with tickers written in alphabetical order.
 
 A scheduled GitHub Action (`.github/workflows/daily-data.yml`) executes the script daily and commits new CSV files automatically.

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "stock-checker",
   "version": "1.0.0",
   "scripts": {
-    "start": "tsx src/index.ts --ticker=TSLA,PLTR,IONQ,GEV,RXRX,DNA,BMNR",
-    "start:pretty": "tsx src/index.ts --ticker=TSLA,PLTR,IONQ,GEV,RXRX,DNA,BMNR | pino-pretty"
+    "start": "tsx src/index.ts --ticker=TSLA,PLTR,IONQ,GEV,RXRX,DNA,BMNR,INTC,UPST",
+    "start:pretty": "tsx src/index.ts --ticker=TSLA,PLTR,IONQ,GEV,RXRX,DNA,BMNR,INTC,UPST | pino-pretty"
   },
   "dependencies": {
     "commander": "^14.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -364,6 +364,8 @@ async function writeToCsv(data: TickerResult[]) {
     return;
   }
 
+  const sorted = [...data].sort((a, b) => a.ticker.localeCompare(b.ticker));
+
   if (!fs.existsSync(CSV_DIR)) {
     fs.mkdirSync(CSV_DIR, { recursive: true });
   }
@@ -393,7 +395,7 @@ async function writeToCsv(data: TickerResult[]) {
     csv += header + '\n';
   }
 
-  data.forEach((item) => {
+  sorted.forEach((item) => {
     const row = [
       item.date,
       item.ticker,


### PR DESCRIPTION
## Summary
- include INTC and UPST in start script and daily workflow
- sort CSV rows by ticker symbol

## Testing
- `pnpm start --ticker=INTC,UPST` *(fails: fetch failed: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_689fc8729c1c832895d88741400585cf