### PR TITLE
feat: add atr-based stop loss guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This project fetches daily stock data for multiple tickers using `yahoo-finance2
 - Fear & Greed Index (alternative.me)
 - Derived BUY/HOLD/SELL opinion weighted by indicator reliability and basic pattern detection
 - Basic detection of bullish chart patterns (ascending triangle, bullish flag, double bottom, falling wedge, island reversal)
+- Volatility-adjusted stop loss, take profit, and trailing stop suggestions (1.5×ATR stop, trailing activates after 0.5×ATR move and never tighter than the initial stop)
 
 ## Usage
 1. **Install & run**


### PR DESCRIPTION
## Summary
- refine trailing stop logic to activate after a 0.5×ATR move and keep distance no tighter than the initial stop
- expose trailing start levels in Slack messages and CSV output
- document how trailing stops activate after breakeven in the README

## Testing
- `pnpm exec tsc --noEmit && echo tsc-ok`
- `pnpm start --ticker=TSLA --slack-webhook=http://example.com` *(fails: fetch failed: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_689fca31b4fc8328a351223abadb1338