### PR TITLE
Fix README markdown formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,31 +12,27 @@ This project fetches daily stock data for multiple tickers using `yahoo-finance2
 - Fear & Greed Index (alternative.me)
 - Derived BUY/HOLD/SELL opinion weighted by indicator reliability and basic pattern detection
 - Basic detection of bullish chart patterns (ascending triangle, bullish flag, double bottom, falling wedge, island reversal)
-- Volatility-adjusted stop loss, take profit, and trailing stop suggestions (1.5×ATR stop, trailing activates after 0.5×ATR move and never tighter than the initial stop)
+- Volatility-adjusted stop loss, take profit, and trailing stop suggestions (1.5×ATR stop, trailing activates after a 0.5×ATR move and never tightens beyond the initial stop)
 
 ## Usage
 1. **Install & run**
-   ```bash
-  pnpm install
-  pnpm start --ticker=TSLA,PLTR,IONQ,GEV,RXRX,DNA,BMNR,INTC,UPST
-  ```
 
-  Pass any comma-separated list of tickers via `--ticker`. If omitted, the
-  script exits with an error message. Argument parsing is handled by
-  [commander](https://github.com/tj/commander.js).
+    ```bash
+    pnpm install
+    pnpm start --ticker=TSLA,PLTR,IONQ,GEV,RXRX,DNA,BMNR,INTC,UPST
+    ```
 
-   To send Slack notifications for tickers that return a **BUY** or **SELL**
-   opinion, provide a webhook URL either via the `--slack-webhook` option or the
-   `SLACK_WEBHOOK_URL` environment variable:
+    Pass any comma-separated list of tickers via `--ticker`. If omitted, the script exits with an error message. Argument parsing is handled by [commander](https://github.com/tj/commander.js).
 
-   ```bash
-   SLACK_WEBHOOK_URL=https://hooks.slack.com/services/XXX pnpm start --ticker=TSLA,PLTR
-   # or
-   pnpm start --ticker=TSLA,PLTR --slack-webhook=https://hooks.slack.com/services/XXX
-   ```
+    To send Slack notifications for tickers that return a **BUY** or **SELL** opinion, provide a webhook URL either via the `--slack-webhook` option or the `SLACK_WEBHOOK_URL` environment variable:
 
-   Each Slack message starts with the date, ticker, and opinion followed by
-   bullet-pointed indicator values.
+    ```bash
+    SLACK_WEBHOOK_URL=https://hooks.slack.com/services/XXX pnpm start --ticker=TSLA,PLTR
+    # or
+    pnpm start --ticker=TSLA,PLTR --slack-webhook=https://hooks.slack.com/services/XXX
+    ```
+
+    Each Slack message starts with the date, ticker, and opinion followed by bullet-pointed indicator values.
 
 Each run appends data to a file named `public/stock_data_YYYYMMDD.csv`, with tickers written in alphabetical order.
 


### PR DESCRIPTION
## Summary
- clean up README markdown with proper code block indentation
- clarify volatility-adjusted stop suggestion description

## Testing
- `pnpm test` *(fails: Unsupported engine; no tests run)*

------
https://chatgpt.com/codex/tasks/task_e_689ff6587d9c8328a1cf35cb0ae07fb7